### PR TITLE
Return mock roles from getRoles API

### DIFF
--- a/app/api/roles/getRoles/route.ts
+++ b/app/api/roles/getRoles/route.ts
@@ -1,24 +1,18 @@
 
-import { db } from "@/lib/db";
-import { auth } from "@/lib/auth"
-import { rolesInHrm } from "drizzle/schema";
-import { eq } from "drizzle-orm";
+import { auth } from "@/lib/auth";
 
-export async function GET() {
+const mockRoles = [
+  { id: 1, role_name: "Admin", active_status: true },
+  { id: 2, role_name: "Manager", active_status: true },
+  { id: 3, role_name: "Guest", active_status: true }
+];
+
+export async function GET(): Promise<Response> {
   const session = await auth();
 
   if(!session){
     return Response.json({error: 'Unauthorized Access!'}, {status:401})
   }
 
-  const data = await db.select(
-    {
-      id: rolesInHrm.id,
-      role_name: rolesInHrm.role_name,
-      active_status: rolesInHrm.active_status
-    }
-  ).from(rolesInHrm)
-  .where(eq(rolesInHrm.active_status, true));
-  
-  return Response.json(data);
+  return Response.json(mockRoles);
 }


### PR DESCRIPTION
## Summary
- replace database call in `/api/roles/getRoles` with static mock data
- remove Drizzle ORM imports

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6876f29d244c8322a78c601cde2c674a